### PR TITLE
Fix supplmental file filtering and apply member descriptions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use clap::{
 };
 
 use crate::{
-    dump::{Dump, ContentSource},
+    dump::{Dump, ContentSource, DumpClassMember},
     supplement::SupplementalData,
     reflection_metadata::ReflectionMetadata,
     dump_devhub::DevHubData,
@@ -49,10 +49,38 @@ fn apply_reflection_metadata(dump: &mut Dump, metadata: &ReflectionMetadata) {
 
 fn apply_supplemental(dump: &mut Dump, content: &SupplementalData) {
     for class in dump.classes.iter_mut() {
-        // TODO: Apply descriptions for instance members too
         if let Some(description) = content.item_descriptions.get(&class.name) {
             class.description = Some(description.prose.clone());
             class.description_source = Some(ContentSource::Supplemental);
+        }
+
+        for member in class.members.iter_mut() {
+            match member {
+                DumpClassMember::Function(function) => {
+                    if let Some(description) = content.item_descriptions.get(&format!("{}.{}", &class.name, &function.name)) {
+                        function.description = Some(description.prose.clone());
+                        function.description_source = Some(ContentSource::Supplemental);
+                    }
+                },
+                DumpClassMember::Property(property) => {
+                    if let Some(description) = content.item_descriptions.get(&format!("{}.{}", &class.name, &property.name)) {
+                        property.description = Some(description.prose.clone());
+                        property.description_source = Some(ContentSource::Supplemental);
+                    }
+                },
+                DumpClassMember::Event(event) => {
+                    if let Some(description) = content.item_descriptions.get(&format!("{}.{}", &class.name, &event.name)) {
+                        event.description = Some(description.prose.clone());
+                        event.description_source = Some(ContentSource::Supplemental);
+                    }
+                },
+                DumpClassMember::Callback(callback) => {
+                    if let Some(description) = content.item_descriptions.get(&format!("{}.{}", &class.name, &callback.name)) {
+                        callback.description = Some(description.prose.clone());
+                        callback.description_source = Some(ContentSource::Supplemental);
+                    }
+                },
+            }
         }
     }
 }

--- a/src/supplement.rs
+++ b/src/supplement.rs
@@ -83,14 +83,26 @@ fn read_item_descriptions_from_path(path: &Path, output: &mut HashMap<String, It
     let metadata = fs::metadata(path)?;
 
     if metadata.is_file() {
-        let contents = fs::read_to_string(path)?;
-        parse_item_descriptions(&contents, output)?;
+        // Only parse .md files.
+        if let Some(extension) = path.extension() {
+            if extension.to_str().expect("File extension was not valid UTF-8.") == "md" {
+                let contents = fs::read_to_string(path)?;
+                parse_item_descriptions(&contents, output)?;
+            }
+        }
 
         Ok(())
     } else if metadata.is_dir() {
         for entry in fs::read_dir(path)? {
             let entry = entry?;
             let entry_path = entry.path();
+
+            // Skip dot directories like ".git"
+            if let Some(entry_name) = path.file_name() {
+                if entry_name.to_str().expect("Directory name was not valid UTF-8.").starts_with(".") {
+                    return Ok(());
+                }
+            }
 
             read_item_descriptions_from_path(&entry_path, output)?;
         }


### PR DESCRIPTION
Restrict supplemental file filtering to exclude dot directories like .git and only parse *.md files. Also actually apply those descriptions to class members.

Probably not idiomatic Rust. If there's cleaner ways to do this, let me know.

Required fixes to make rodocs/docs usable with dumpling along with my other PR updating the front matter.